### PR TITLE
[review] delayed_cron_job のリストを表示する rake タスク

### DIFF
--- a/lib/sg_fargate_rails/delayed_cron_job_utility.rb
+++ b/lib/sg_fargate_rails/delayed_cron_job_utility.rb
@@ -8,6 +8,24 @@ module SgFargateRails
       def cron_jobs
         Delayed::Job.where.not(cron: nil)
       end
+
+      def list_cron_jobs
+        cron_jobs.order(id: :asc).map do |cron_job|
+          job_data = cron_job.payload_object.job_data
+          job_class = job_data['job_class']
+          job_arguments = job_data['arguments']
+
+          puts [
+            cron_job.cron,
+            "job_data  : #{job_class}",
+            "job_args  : #{job_arguments}",
+            "queue     : #{cron_job.queue}",
+            "run_at    : #{cron_job.run_at.to_s}",
+            "created_at: #{cron_job.created_at.to_s}",
+            "\n",
+          ].join("\n")
+        end
+      end
     end
 
     def initialize

--- a/lib/sg_fargate_rails/delayed_cron_job_utility.rb
+++ b/lib/sg_fargate_rails/delayed_cron_job_utility.rb
@@ -8,6 +8,22 @@ module SgFargateRails
       def cron_jobs
         Delayed::Job.where.not(cron: nil)
       end
+
+      def formatted_cron_jobs
+        cron_jobs.order(id: :asc).map { |cron_job| format(cron_job) }
+      end
+
+      def format(cron_job)
+        job_data = cron_job.payload_object.job_data
+        <<~TEXT
+          #{cron_job.cron}
+          job_class : #{job_data['job_class']}
+          job_args  : #{job_data['arguments']}
+          queue     : #{cron_job.queue}
+          run_at    : #{cron_job.run_at.to_s}
+          created_at: #{cron_job.created_at.to_s}
+        TEXT
+      end
     end
 
     def initialize

--- a/lib/sg_fargate_rails/delayed_cron_job_utility.rb
+++ b/lib/sg_fargate_rails/delayed_cron_job_utility.rb
@@ -8,24 +8,6 @@ module SgFargateRails
       def cron_jobs
         Delayed::Job.where.not(cron: nil)
       end
-
-      def list_cron_jobs
-        cron_jobs.order(id: :asc).map do |cron_job|
-          job_data = cron_job.payload_object.job_data
-          job_class = job_data['job_class']
-          job_arguments = job_data['arguments']
-
-          puts [
-            cron_job.cron,
-            "job_data  : #{job_class}",
-            "job_args  : #{job_arguments}",
-            "queue     : #{cron_job.queue}",
-            "run_at    : #{cron_job.run_at.to_s}",
-            "created_at: #{cron_job.created_at.to_s}",
-            "\n",
-          ].join("\n")
-        end
-      end
     end
 
     def initialize

--- a/lib/tasks/sg_fargate_rails.rake
+++ b/lib/tasks/sg_fargate_rails.rake
@@ -32,11 +32,17 @@ namespace :sg_fargate_rails do
 
   if defined?(::DelayedCronJob)
     require 'sg_fargate_rails/delayed_cron_job_utility'
+
     desc 'Refresh Delayed Cron Jobs'
     task refresh_delayed_cron_jobs: :environment do
       Rails.logger.info('[refresh_delayed_cron_jobs] refresh begin...')
       SgFargateRails::DelayedCronJobUtility.refresh_cron_jobs!
       Rails.logger.info('[refresh_delayed_cron_jobs] refresh end.')
+    end
+
+    desc 'List Delayed Cron Jobs'
+    task list_delayed_cron_jobs: :environment do
+      SgFargateRails::DelayedCronJobUtility.list_cron_jobs
     end
   end
 end

--- a/lib/tasks/sg_fargate_rails.rake
+++ b/lib/tasks/sg_fargate_rails.rake
@@ -42,7 +42,18 @@ namespace :sg_fargate_rails do
 
     desc 'List Delayed Cron Jobs'
     task list_delayed_cron_jobs: :environment do
-      SgFargateRails::DelayedCronJobUtility.list_cron_jobs
+      SgFargateRails::DelayedCronJobUtility.cron_jobs.order(id: :asc).each do |cron_job|
+        job_data = cron_job.payload_object.job_data
+        puts [
+          cron_job.cron,
+          "job_class : #{job_data['job_class']}",
+          "job_args  : #{job_data['arguments']}",
+          "queue     : #{cron_job.queue}",
+          "run_at    : #{cron_job.run_at.to_s}",
+          "created_at: #{cron_job.created_at.to_s}",
+        ].join("\n")
+        puts "\n"
+      end
     end
   end
 end

--- a/lib/tasks/sg_fargate_rails.rake
+++ b/lib/tasks/sg_fargate_rails.rake
@@ -44,14 +44,15 @@ namespace :sg_fargate_rails do
     task list_delayed_cron_jobs: :environment do
       SgFargateRails::DelayedCronJobUtility.cron_jobs.order(id: :asc).each do |cron_job|
         job_data = cron_job.payload_object.job_data
-        puts [
-          cron_job.cron,
-          "job_class : #{job_data['job_class']}",
-          "job_args  : #{job_data['arguments']}",
-          "queue     : #{cron_job.queue}",
-          "run_at    : #{cron_job.run_at.to_s}",
-          "created_at: #{cron_job.created_at.to_s}",
-        ].join("\n")
+
+        puts <<~TEXT
+          cron_job.cron
+          job_class : #{job_data['job_class']}
+          job_args  : #{job_data['arguments']}
+          queue     : #{cron_job.queue}
+          run_at    : #{cron_job.run_at.to_s}
+          created_at: #{cron_job.created_at.to_s}
+        TEXT
         puts "\n"
       end
     end

--- a/lib/tasks/sg_fargate_rails.rake
+++ b/lib/tasks/sg_fargate_rails.rake
@@ -42,17 +42,8 @@ namespace :sg_fargate_rails do
 
     desc 'List Delayed Cron Jobs'
     task list_delayed_cron_jobs: :environment do
-      SgFargateRails::DelayedCronJobUtility.cron_jobs.order(id: :asc).each do |cron_job|
-        job_data = cron_job.payload_object.job_data
-
-        puts <<~TEXT
-          cron_job.cron
-          job_class : #{job_data['job_class']}
-          job_args  : #{job_data['arguments']}
-          queue     : #{cron_job.queue}
-          run_at    : #{cron_job.run_at.to_s}
-          created_at: #{cron_job.created_at.to_s}
-        TEXT
+      SgFargateRails::DelayedCronJobUtility.formatted_cron_jobs.each do |formatted_cron_job|
+        puts formatted_cron_job
         puts "\n"
       end
     end


### PR DESCRIPTION
### 実行結果サンプル

```
> bin/rails sg_fargate_rails:list_delayed_cron_jobs
0 * * * *
job_data  : Jobmon::TaskJob
job_args  : [{"task"=>"cron:hourly_hello", "_aj_ruby2_keywords"=>["task"]}]
queue     : default
run_at    : 2023-12-15 18:00:00 +0900
created_at: 2023-12-15 16:08:08 +0900

5 8 * * *
job_data  : Jobmon::TaskJob
job_args  : [{"task"=>"cron:daily_hello", "_aj_ruby2_keywords"=>["task"]}]
queue     : default
run_at    : 2023-12-16 08:05:00 +0900
created_at: 2023-12-15 16:08:08 +0900

10 8 * * 0
job_data  : Jobmon::TaskJob
job_args  : [{"task"=>"cron:weekly_hello", "_aj_ruby2_keywords"=>["task"]}]
queue     : default
run_at    : 2023-12-17 08:10:00 +0900
created_at: 2023-12-15 16:08:08 +0900

5 * * * *
job_data  : Jobmon::TaskJob
job_args  : [{"task"=>"jobmon:delayed_job_queue_monitor", "_aj_ruby2_keywords"=>["task"]}]
queue     : default
run_at    : 2023-12-15 18:05:00 +0900
created_at: 2023-12-15 16:08:08 +0900

>
```