### PR TITLE
[review] schedule が未定義なときに例外が発生していたのを修正

### DIFF
--- a/lib/sg_fargate_rails/event_bridge_schedule.rb
+++ b/lib/sg_fargate_rails/event_bridge_schedule.rb
@@ -94,7 +94,7 @@ module SgFargateRails
 
     class << self
       def convert(schedules)
-        schedules.map { |name, info| EventBridgeSchedule.new(name.to_s, info[:cron], info[:command], info[:container_type]) }
+        schedules.to_h.map { |name, info| EventBridgeSchedule.new(name.to_s, info[:cron], info[:command], info[:container_type]) }
       end
 
       def delete_all!(group_name)

--- a/spec/sg_fargate_rails/event_bridge_schedule_spec.rb
+++ b/spec/sg_fargate_rails/event_bridge_schedule_spec.rb
@@ -51,7 +51,7 @@ describe SgFargateRails::EventBridgeSchedule do
   describe '.convert' do
     context 'scheduleの登録がない場合' do
       it do
-        expect(SgFargateRails::EventBridgeSchedule.convert({})).to eq []
+        expect(SgFargateRails::EventBridgeSchedule.convert(nil)).to eq []
       end
     end
 


### PR DESCRIPTION
[sg_fargate_rails_generator で出力される yaml](https://github.com/SonicGarden/sg_fargate_rails_generator/blob/main/lib/generators/sg_fargate_rails_generator/templates/config/eventbridge_schedules.yml#L4) だと、staging などの task が未定義な環境でエラーが発生していたので修正

https://app.bugsnag.com/sonicgarden/world/errors/6572e01655d187000887f154?filters[error.status]=open&filters[event.since]=30d&filters[app.release_stage]=staging&pivot_tab=event