### PR TITLE
[review] Blazer と GoodJob の追加認証

### DIFF
--- a/lib/sg_fargate_rails/railtie.rb
+++ b/lib/sg_fargate_rails/railtie.rb
@@ -46,7 +46,7 @@ module SgFargateRails
           return unless defined?(::GoodJob)
           return unless self.class.module_parent == ::GoodJob
 
-          unless accessible_to_good_job?
+          unless try(:accessible_to_good_job?)
             raise 'unauthorized good_job user.'
           end
         end
@@ -55,7 +55,7 @@ module SgFargateRails
           return unless defined?(::Blazer)
           return unless self.class.module_parent == ::Blazer
 
-          unless accessible_to_blazer?
+          unless try(:accessible_to_blazer?)
             raise 'unauthorized blazer user.'
           end
         end

--- a/lib/sg_fargate_rails/railtie.rb
+++ b/lib/sg_fargate_rails/railtie.rb
@@ -26,7 +26,7 @@ module SgFargateRails
         Blazer::Plus.blazer_danger_actionable_method ||= ->(blazer_user) { blazer_user.email.ends_with?('@sonicgarden.jp') }
 
         # NOTE: すべての callback をすてているので致し方なく Blazer の用意している callback を利用する
-        Blazer.before_action = :authenticate_sg_system_administrator!
+        Blazer.before_action = :authenticate_user_to_access_blazer!
       end
 
       ActiveSupport.on_load(:good_job_application_controller) do
@@ -41,7 +41,6 @@ module SgFargateRails
 
       ActiveSupport.on_load(:action_controller_base) do
         prepend_before_action :authenticate_user_to_access_good_job!
-        prepend_before_action :authenticate_user_to_access_blazer!
 
         def authenticate_user_to_access_good_job!
           return unless defined?(::GoodJob)

--- a/lib/sg_fargate_rails/railtie.rb
+++ b/lib/sg_fargate_rails/railtie.rb
@@ -60,21 +60,6 @@ module SgFargateRails
           end
         end
       end
-
-      # TODO: sg_fargate_rails_generator で config/initializers/sg_fargate_rails.rb に以下のようなコードコメントを追加する
-      # ActiveSupport.on_load(:action_controller_base) do
-      #   def accessible_to_good_job?
-      #     # TODO: 各プロジェクトでアカウントの検証をしてください
-      #     # current_admin&.email&.end_with?('@sonicgarden.jp')
-      #     false
-      #   end
-      #
-      #   def accessible_to_blazer?
-      #     # TODO: 各プロジェクトでアカウントの検証をしてください
-      #     # current_admin&.email&.end_with?('@sonicgarden.jp')
-      #     false
-      #   end
-      # end
     end
   end
 end

--- a/lib/sg_fargate_rails/railtie.rb
+++ b/lib/sg_fargate_rails/railtie.rb
@@ -40,28 +40,37 @@ module SgFargateRails
       end
 
       ActiveSupport.on_load(:action_controller_base) do
-        prepend_before_action :authenticate_sg_system_administrator!
+        prepend_before_action :authenticate_user_to_access_good_job!
+        prepend_before_action :authenticate_user_to_access_blazer!
 
-        def requires_sg_system_administrator?
-          # FIXME: module の検査方法は調査・修正する
-          return true if defined?(::Blazer) && self.class.to_s.include?('Blazer::')
-          return true if defined?(::GoodJob) && self.class.to_s.include?('GoodJob::')
+        def authenticate_user_to_access_good_job!
+          return unless defined?(::GoodJob)
+          return unless self.class.module_parent == ::GoodJob
 
-          false
+          unless accessible_user_to_good_job?
+            raise 'unauthorized good_job user.'
+          end
         end
 
-        def authenticate_sg_system_administrator!
-          return unless requires_sg_system_administrator?
+        def authenticate_user_to_access_blazer!
+          return unless defined?(::Blazer)
+          return unless self.class.module_parent == ::Blazer
 
-          if !sg_system_administrator_signed_in?
-            raise 'unauthorized system administrator.'
+          unless accessible_user_to_blazer?
+            raise 'unauthorized blazer user.'
           end
         end
       end
 
       # TODO: sg_fargate_rails_generator で config/initializers/sg_fargate_rails.rb に以下のようなコードコメントを追加する
       # ActiveSupport.on_load(:action_controller_base) do
-      #   def sg_system_administrator_signed_in?
+      #   def accessible_user_to_good_job?
+      #     # TODO: 各プロジェクトでアカウントの検証をしてください
+      #     # current_admin&.email&.end_with?('@sonicgarden.jp')
+      #     false
+      #   end
+      #
+      #   def accessible_user_to_blazer?
       #     # TODO: 各プロジェクトでアカウントの検証をしてください
       #     # current_admin&.email&.end_with?('@sonicgarden.jp')
       #     false

--- a/lib/sg_fargate_rails/railtie.rb
+++ b/lib/sg_fargate_rails/railtie.rb
@@ -47,7 +47,7 @@ module SgFargateRails
           return unless defined?(::GoodJob)
           return unless self.class.module_parent == ::GoodJob
 
-          unless accessible_user_to_good_job?
+          unless accessible_to_good_job?
             raise 'unauthorized good_job user.'
           end
         end
@@ -56,7 +56,7 @@ module SgFargateRails
           return unless defined?(::Blazer)
           return unless self.class.module_parent == ::Blazer
 
-          unless accessible_user_to_blazer?
+          unless accessible_to_blazer?
             raise 'unauthorized blazer user.'
           end
         end
@@ -64,13 +64,13 @@ module SgFargateRails
 
       # TODO: sg_fargate_rails_generator で config/initializers/sg_fargate_rails.rb に以下のようなコードコメントを追加する
       # ActiveSupport.on_load(:action_controller_base) do
-      #   def accessible_user_to_good_job?
+      #   def accessible_to_good_job?
       #     # TODO: 各プロジェクトでアカウントの検証をしてください
       #     # current_admin&.email&.end_with?('@sonicgarden.jp')
       #     false
       #   end
       #
-      #   def accessible_user_to_blazer?
+      #   def accessible_to_blazer?
       #     # TODO: 各プロジェクトでアカウントの検証をしてください
       #     # current_admin&.email&.end_with?('@sonicgarden.jp')
       #     false

--- a/lib/sg_fargate_rails/railtie.rb
+++ b/lib/sg_fargate_rails/railtie.rb
@@ -26,7 +26,7 @@ module SgFargateRails
         Blazer::Plus.blazer_danger_actionable_method ||= ->(blazer_user) { blazer_user.email.ends_with?('@sonicgarden.jp') }
 
         # NOTE: すべての callback をすてているので致し方なく Blazer の用意している callback を利用する
-        Blazer.before_action = :authenticate_user_to_access_blazer!
+        Blazer.before_action = :authenticate_to_access_blazer!
       end
 
       ActiveSupport.on_load(:good_job_application_controller) do
@@ -40,9 +40,9 @@ module SgFargateRails
       end
 
       ActiveSupport.on_load(:action_controller_base) do
-        prepend_before_action :authenticate_user_to_access_good_job!
+        prepend_before_action :authenticate_to_access_good_job!
 
-        def authenticate_user_to_access_good_job!
+        def authenticate_to_access_good_job!
           return unless defined?(::GoodJob)
           return unless self.class.module_parent == ::GoodJob
 
@@ -51,7 +51,7 @@ module SgFargateRails
           end
         end
 
-        def authenticate_user_to_access_blazer!
+        def authenticate_to_access_blazer!
           return unless defined?(::Blazer)
           return unless self.class.module_parent == ::Blazer
 


### PR DESCRIPTION
以下のメソッドを initializer や `config/application.rb` などで定義する

```ruby
ActiveSupport.on_load(:action_controller_base) do
  def accessible_to_good_job?
    # e.g. メールドメインで判定する場合
    current_user&.email&.end_with?('@example.com')
  end
  
  def accessible_to_blazer?
    current_user&.admin?
  end
end
```