### PR TITLE
update: bundler, puma, nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,18 +75,22 @@ GEM
     loofah (2.21.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mini_portile2 (2.8.7)
+    mini_portile2 (2.8.9)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    nio4r (2.5.9)
-    nokogiri (1.15.4)
+    nio4r (2.7.4)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     psych (5.1.1.1)
       stringio
-    puma (6.3.0)
+    puma (6.6.0)
       nio4r (~> 2.0)
-    racc (1.7.3)
+    racc (1.8.1)
     rack (3.0.8)
     rack-session (2.0.0)
       rack (>= 3.0.0)
@@ -141,6 +145,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-24
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -149,4 +154,4 @@ DEPENDENCIES
   sg_fargate_rails!
 
 BUNDLED WITH
-   2.4.17
+   2.7.1


### PR DESCRIPTION
3.1だと bundler 2.6.9 だし、1.18.9は使えなさそうなので、[Ruby 3.1のEOL対応](https://sg-ops.sg-apps.com/teams/1/inventories/297)の完了を待ったほうが良さそう。