### PR TITLE
chore: バージョンを 0.4.0 に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sg_fargate_rails (0.3.2)
+    sg_fargate_rails (0.4.0)
       aws-sdk-ec2 (~> 1.413)
       aws-sdk-scheduler (~> 1.10)
       lograge (~> 0.12)

--- a/lib/sg_fargate_rails/version.rb
+++ b/lib/sg_fargate_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SgFargateRails
-  VERSION = "0.3.2"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
## 概要

リリース向けにバージョンを 0.3.2 から 0.4.0 に更新します。

## 背景

#70 で `required_ruby_version` を `>= 2.7.0` から `>= 3.3` に引き上げました。Ruby 3.2 以下の環境では `bundle install` が解決に失敗する破壊的変更のため、パッチではなくマイナーバージョンを上げます。

`~> 0.3.1` のような指定をしている利用者が意図せず解決不能になるのを避ける狙いです。

## 変更内容

- `lib/sg_fargate_rails/version.rb` の `VERSION` を `0.4.0` に更新
- 追従して `Gemfile.lock` の `sg_fargate_rails (0.4.0)` を更新

## リリースノート想定

```markdown
## Breaking Changes
- サポート対象 Ruby を 3.3 以上に変更しました (`required_ruby_version >= 3.3`)。
  Ruby 3.2 以下をお使いの場合は 0.3.1 以前をご利用ください。
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)